### PR TITLE
Switch to Slim CLI exit Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ These images are examples using popular base images such as `node:latest`. They 
 
  <tr id="docker.io-library-node-latest">
     <td class="project-name"><a href="community-images/docker.io/library/node/latest">NodeJS Hello World</a></td>
-    <td class="project-status"><a href="https://github.com/slimdevops/community-images/actions/runs/6877711311"><img src="https://img.shields.io/badge/Build-Passing-green.svg" /></a></td>
+    <td class="project-status"><a href="https://github.com/slimdevops/community-images/actions/runs/6877921166"><img src="https://img.shields.io/badge/Build-Passing-green.svg" /></a></td>
     <td class="project-image">library/node:latest</td>
-    <td class="project-last-update">2023-11-15T13:12:39.017Z</td>
+    <td class="project-last-update">2023-11-15T13:31:45.274Z</td>
     </tr>
  <tr id="docker.io-library-rust-latest">
     <td class="project-name"><a href="community-images/docker.io/library/rust/latest">Rust Hello World</a></td>

--- a/bin/cli_instrument.sh
+++ b/bin/cli_instrument.sh
@@ -37,12 +37,13 @@ log_output=$(slim instrument \
   $extraArgs \
   $BASEIMAGE 2>&1 | tee /dev/stderr)
 
-workflow_id=$(echo "$log_output" | grep -Eo 'workflow id: [a-zA-Z0-9\.]+')
-workflow_id=${workflow_id#"workflow id: "}
-
-if [[ $log_output =~ "[instrument] instrumented" ]]; then
+if [[ "$?" == "0" ]]; then
+  workflow_id=$(echo "$log_output" | grep -Eo 'workflow id: [a-zA-Z0-9\.]+')
+  workflow_id=${workflow_id#"workflow id: "}
   echo "The image has been successfully instrumented ($workflow_id)."
 else
+  workflow_id=$(echo "$log_output" | grep -Eo 'workflow id: [a-zA-Z0-9\.]+')
+  workflow_id=${workflow_id#"workflow id: "}
   echo "The image instrumentation failed ($workflow_id)."
   exit 1
 fi

--- a/bin/harden.sh
+++ b/bin/harden.sh
@@ -3,7 +3,7 @@
 echo "Hardening workflow: $SLIMAI_WORKFLOW_ID"
 log_output=$(slim harden --timeout 30m --id $SLIMAI_WORKFLOW_ID 2>&1 | tee /dev/stderr)
 
-if [[ $log_output =~ "[harden] completed" ]]; then
+if [[ "$?" == "0" ]]; then
   echo "The image has been successfully hardened ($SLIMAI_WORKFLOW_ID)."
 else
   echo "The image hardening failed ($SLIMAI_WORKFLOW_ID)."


### PR DESCRIPTION
Since the exit code issues are fixed on CLI, we can switch to exit code instead of parsing the result message.